### PR TITLE
Adds follow drafted master icon, Fixes missing weapon icon

### DIFF
--- a/Languages/English/Keyed/AutoEnglish.xml
+++ b/Languages/English/Keyed/AutoEnglish.xml
@@ -4,4 +4,5 @@
 	<AGOC.ShowLifeStage>Show life stage</AGOC.ShowLifeStage>
 	<AGOC.ShowGender>Show gender</AGOC.ShowGender>
 	<AGOC.PawnWeaponIconFix>Remove reserved empty weapon icon space</AGOC.PawnWeaponIconFix>
+	<AGOC.FollowDraftedMaster>Show follow master while drafted status</AGOC.FollowDraftedMaster>
 </LanguageData>

--- a/Source/1.4/AnimalsGenderOnCaravan.csproj
+++ b/Source/1.4/AnimalsGenderOnCaravan.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="Core\Mod.cs" />
     <Compile Include="HarmonyPatches\TransferableOneWayWidget_DoRow_Patch.cs" />
+    <Compile Include="HarmonyPatches\TransferableUtility_TransferAsOne_Patch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Core\Resources.cs" />
     <Compile Include="Core\Settings.cs" />

--- a/Source/1.4/Core/Mod.cs
+++ b/Source/1.4/Core/Mod.cs
@@ -16,33 +16,9 @@ namespace AnimalsGenderOnCaravan
         {
             Settings settings = GetSettings<Settings>();
             harmony = new Harmony(id);
-
-            Patch_TransferableUIUtility();
-            Patch_TransferableOneWayWidget(settings.removeReservedWeaponIconSpace);
+            harmony.PatchAll();
         }
-
-        private static void Patch_TransferableUIUtility()
-        {
-            MethodInfo original = typeof(TransferableUIUtility).GetMethod("DoExtraIcons");
-            var prefix = new HarmonyMethod(typeof(TransferableUIUtility_DoExtraIcons_Patch).GetMethod("Prefix"));
-            harmony.Patch(original, prefix: prefix);
-        }
-
-        public static void Patch_TransferableOneWayWidget(bool toggle)
-        {
-            MethodInfo original = typeof(TransferableOneWayWidget).GetMethod("DoRow", BindingFlags.Instance | BindingFlags.NonPublic);
-            if (toggle)
-            {
-                var prefix = new HarmonyMethod(typeof(TransferableOneWayWidget_DoRow_Patch).GetMethod("Prefix"));
-                harmony.Patch(original, prefix: prefix);
-            }
-            else
-            {
-                if (harmony.GetPatchedMethods().Contains(original))
-                    harmony.Unpatch(original, HarmonyPatchType.Prefix);
-            }
-        }
-
+        
         public override void DoSettingsWindowContents(Rect inRect)
         {
             base.DoSettingsWindowContents(inRect);

--- a/Source/1.4/Core/Resources.cs
+++ b/Source/1.4/Core/Resources.cs
@@ -11,16 +11,21 @@ namespace AnimalsGenderOnCaravan
 
         [TweakValue("Interface", 0f, 50f)]
         public static float LifeStageIconWidth = 24f;
+        
+        [TweakValue("Interface", 0f, 50f)]
+        public static float FollowMasterIconWidth = 24f;
 
         public static readonly Texture2D VeryYoungIcon;
         public static readonly Texture2D YoungIcon;
         public static readonly Texture2D AdultIcon;
+        public static readonly Texture2D FollowMasterIcon;
 
         static Resources()
         {
             VeryYoungIcon = ContentFinder<Texture2D>.Get("UI/Icons/LifeStage/VeryYoung", true);
             YoungIcon = ContentFinder<Texture2D>.Get("UI/Icons/LifeStage/Young", true);
             AdultIcon = ContentFinder<Texture2D>.Get("UI/Icons/LifeStage/Adult", true);
+            FollowMasterIcon = ContentFinder<Texture2D>.Get("UI/Icons/Animal/FollowDrafted", true);
         }
     }
 }

--- a/Source/1.4/Core/Settings.cs
+++ b/Source/1.4/Core/Settings.cs
@@ -9,6 +9,7 @@ namespace AnimalsGenderOnCaravan
         public bool humanShowGender = false;
         public bool humanShowLifeStage = false;
         public bool removeReservedWeaponIconSpace = false;
+        public bool showFollowDraftedMaster = false;
 
         public static Settings Get()
         {
@@ -26,6 +27,9 @@ namespace AnimalsGenderOnCaravan
             // Show life stage
             DrawLifeStage(listing_Standard, ref showLifeStage);
             
+            // Show Follow Drafted Master
+            listing_Standard.CheckboxLabeled("AGOC.FollowDraftedMaster".Translate(), ref showFollowDraftedMaster, null);
+            
             listing_Standard.Gap();
             
             // Colonists
@@ -38,20 +42,19 @@ namespace AnimalsGenderOnCaravan
             DrawLifeStage(listing_Standard, ref humanShowLifeStage);
             
             // Remove reserved empty weapon icon space
-            bool changed = removeReservedWeaponIconSpace;
             listing_Standard.CheckboxLabeled("AGOC.PawnWeaponIconFix".Translate(), ref removeReservedWeaponIconSpace, null);
-            if (changed != removeReservedWeaponIconSpace)
-                AnimalsGenderOnCaravan.Mod.Patch_TransferableOneWayWidget(removeReservedWeaponIconSpace);
+            
             
             listing_Standard.End();
         }
         
         public override void ExposeData()
         {
-            Scribe_Values.Look(ref showLifeStage, "showLifeStage", true, false);
-            Scribe_Values.Look(ref humanShowGender, "humanShowGender", false, false);
-            Scribe_Values.Look(ref humanShowLifeStage, "humanShowLifeStage", false, false);
-            Scribe_Values.Look(ref removeReservedWeaponIconSpace, "removeReservedWeaponIconSpace", false, false);
+            Scribe_Values.Look(ref showLifeStage, nameof(showLifeStage), true, false);
+            Scribe_Values.Look(ref humanShowGender, nameof(humanShowGender), false, false);
+            Scribe_Values.Look(ref humanShowLifeStage, nameof(humanShowLifeStage), false, false);
+            Scribe_Values.Look(ref removeReservedWeaponIconSpace, nameof(removeReservedWeaponIconSpace), false, false);
+            Scribe_Values.Look(ref showFollowDraftedMaster, nameof(showFollowDraftedMaster), false, false);
         }
         
         private void DrawLifeStage(Listing_Standard listing, ref bool enabled)

--- a/Source/1.4/HarmonyPatches/TransferableOneWayWidget_DoRow_Patch.cs
+++ b/Source/1.4/HarmonyPatches/TransferableOneWayWidget_DoRow_Patch.cs
@@ -15,11 +15,27 @@ namespace AnimalsGenderOnCaravan
             AccessTools.FieldRefAccess<TransferableOneWayWidget, bool>("drawEquippedWeapon");
 
         [HarmonyPrefix]
-        public static void Prefix(TransferableOneWayWidget __instance, Rect rect, TransferableOneWay trad, int index, float availableMass)
+        public static void Prefix(out bool __state, TransferableOneWayWidget __instance, Rect rect, TransferableOneWay trad, int index, float availableMass)
         {
-            Pawn pawn = trad.AnyThing as Pawn;
-            bool shouldDrawWeapon = pawn != null && pawn.equipment != null && pawn.equipment.Primary != null;
-            drawEquippedWeapon(__instance) = drawEquippedWeapon(__instance) && shouldDrawWeapon;
+            // save original value so we can make a new decision for each row
+            __state = drawEquippedWeapon(__instance);
+
+            if (Settings.Get().removeReservedWeaponIconSpace)
+            {
+                // change for current method according to pawn equipment
+                Pawn pawn = trad.AnyThing as Pawn;
+                bool shouldDrawWeapon = pawn != null && pawn.equipment != null && pawn.equipment.Primary != null;
+                drawEquippedWeapon(__instance) = shouldDrawWeapon;
+            }
+            
+        }
+        
+        [HarmonyPostfix]
+        public static void Postfix(bool __state, TransferableOneWayWidget __instance, Rect rect, TransferableOneWay trad, int index,
+            float availableMass)
+        {
+            // revert to original value
+            drawEquippedWeapon(__instance) = __state;
         }
     }
 }

--- a/Source/1.4/HarmonyPatches/TransferableUIUtility_DoExtraIcons_Patch.cs
+++ b/Source/1.4/HarmonyPatches/TransferableUIUtility_DoExtraIcons_Patch.cs
@@ -43,6 +43,19 @@ namespace AnimalsGenderOnCaravan
                     TooltipHandler.TipRegion(rect1, pawn.GetGenderLabel().CapitalizeFirst());
                     GUI.DrawTexture(rect1, genderIcon);
                 }
+
+                // Follow Drafted Master icon
+                if (settings.showFollowDraftedMaster)
+                {
+                    if (pawn.playerSettings?.followDrafted ?? false)
+                    {
+                        var followMasterIcon = Resources.FollowMasterIcon;
+                        var rectIcon = new Rect(curX - Resources.FollowMasterIconWidth, (rect.height - Resources.FollowMasterIconWidth) / 2f, Resources.FollowMasterIconWidth, Resources.FollowMasterIconWidth);
+                        curX -= Resources.FollowMasterIconWidth;
+                        TooltipHandler.TipRegion(rectIcon, "CreatureFollowDrafted".Translate());
+                        GUI.DrawTexture(rectIcon, followMasterIcon);
+                    }
+                }
             }
         }
     }

--- a/Source/1.4/HarmonyPatches/TransferableUtility_TransferAsOne_Patch.cs
+++ b/Source/1.4/HarmonyPatches/TransferableUtility_TransferAsOne_Patch.cs
@@ -1,0 +1,50 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace AnimalsGenderOnCaravan
+{
+    /// <summary>
+    /// Avoid Stacking of different training (only Attack training is checked)
+    /// </summary>
+    [HarmonyPatch(typeof(TransferableUtility), nameof(TransferableUtility.TransferAsOne))]
+    public class TransferableUtility_TransferAsOne_Patch
+    {
+        [HarmonyPrefix]
+        public static bool Prefix(ref bool __result, Thing a, Thing b, TransferAsOneMode mode)
+        {
+            if (a.def.category == ThingCategory.Pawn && b.def == a.def)
+            {
+                Pawn pawn1 = (Pawn) a;
+                Pawn pawn2 = (Pawn) b;
+                if (pawn1.RaceProps.Animal)
+                {
+                    var attackTraining = TrainableDefOf.Release;
+                    if (
+                        pawn1.training.HasLearned(attackTraining) ^
+                        pawn2.training.HasLearned(attackTraining)
+                        )
+                    {
+                        // if one has learned to be released for attacking and the other one not then avoid stacking
+                        __result = false;
+                        return false; // skip original
+                    }
+
+                    if (
+                        (pawn1.playerSettings?.followDrafted ?? false) ^
+                        (pawn2.playerSettings?.followDrafted ?? false)
+                        )
+                    {
+                        // if one has a caller and the other one not then avoid stacking
+                        __result = false;
+                        return false;
+                    }
+                    
+                        
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/1.4/HarmonyPatches/TransferableUtility_TransferAsOne_Patch.cs
+++ b/Source/1.4/HarmonyPatches/TransferableUtility_TransferAsOne_Patch.cs
@@ -5,7 +5,7 @@ using Verse;
 namespace AnimalsGenderOnCaravan
 {
     /// <summary>
-    /// Avoid Stacking of different training (only Attack training is checked)
+    /// Avoid stacking of animals with different stats 
     /// </summary>
     [HarmonyPatch(typeof(TransferableUtility), nameof(TransferableUtility.TransferAsOne))]
     public class TransferableUtility_TransferAsOne_Patch
@@ -13,35 +13,32 @@ namespace AnimalsGenderOnCaravan
         [HarmonyPrefix]
         public static bool Prefix(ref bool __result, Thing a, Thing b, TransferAsOneMode mode)
         {
-            if (a.def.category == ThingCategory.Pawn && b.def == a.def)
+            if (a.def.category != ThingCategory.Pawn || b.def != a.def) 
+                return true; // let original RimWorld decide here
+            
+            var pawn1 = (Pawn) a;
+            var pawn2 = (Pawn) b;
+            if (!pawn1.RaceProps.Animal) 
+                return true;
+            var attackTraining = TrainableDefOf.Release;
+            if (
+                pawn1.training.HasLearned(attackTraining) ^
+                pawn2.training.HasLearned(attackTraining)
+            )
             {
-                Pawn pawn1 = (Pawn) a;
-                Pawn pawn2 = (Pawn) b;
-                if (pawn1.RaceProps.Animal)
-                {
-                    var attackTraining = TrainableDefOf.Release;
-                    if (
-                        pawn1.training.HasLearned(attackTraining) ^
-                        pawn2.training.HasLearned(attackTraining)
-                        )
-                    {
-                        // if one has learned to be released for attacking and the other one not then avoid stacking
-                        __result = false;
-                        return false; // skip original
-                    }
+                // if one has learned to be released for attacking and the other one not then avoid stacking
+                __result = false;
+                return false;
+            }
 
-                    if (
-                        (pawn1.playerSettings?.followDrafted ?? false) ^
-                        (pawn2.playerSettings?.followDrafted ?? false)
-                        )
-                    {
-                        // if one has a caller and the other one not then avoid stacking
-                        __result = false;
-                        return false;
-                    }
-                    
-                        
-                }
+            if (
+                (pawn1.playerSettings?.followDrafted ?? false) ^
+                (pawn2.playerSettings?.followDrafted ?? false)
+            )
+            {
+                // if one is set to follow drafted master and the other one not then avoid stacking
+                __result = false;
+                return false;
             }
 
             return true;


### PR DESCRIPTION
This pull request changes harmony patching. Previous behavior patches and unpatches the game upon setting change but now the changes are just realized by a simple `if`-condition in `Prefix`-method.
Do you have a special reason to do it the other way? I changed it so I can easily add harmony patches.

So I could fix the bug that appeared if one of your top sorted colonists have no weapon equipped and all of the colonists below him in the list render with no weapon (If `Remove reserved empty weapon icon space`  setting is turned on).

This pull request also adds a default-off setting to show an icon if the animal is set to follow drafted master.
My war elephant tribe really wants this kind of setting visible in order to avoid sending out untrained brain-shot elephants with no legs.

Also the pull request will change the stacking behavior in this list so that:
- follow drafted master setting have to match in order to stack
- training status of `Attack` have to match in order to stack (I can remove that if you like)